### PR TITLE
Fix parsing IP address when starting cluster

### DIFF
--- a/bin/start-cluster
+++ b/bin/start-cluster
@@ -23,7 +23,7 @@ fi
 
 # start docker containers for 3xreplicaset rs0
 SHARD00_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet rs0 --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT)
-SHARD00_IP=$(sudo docker inspect ${SHARD00_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD00_IP=$(sudo docker inspect ${SHARD00_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD00_ID} listen on ip: ${SHARD00_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD00_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -31,7 +31,7 @@ do
 done
 
 SHARD01_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet rs0 --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port ($PORT+1))
-SHARD01_IP=$(sudo docker inspect ${SHARD01_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD01_IP=$(sudo docker inspect ${SHARD01_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD01_ID} listen on ip: ${SHARD01_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD01_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -39,7 +39,7 @@ do
 done
 
 SHARD02_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet rs0 --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port ($PORT+2))
-SHARD02_IP=$(sudo docker inspect ${SHARD02_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD02_IP=$(sudo docker inspect ${SHARD02_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD02_ID} listen on ip: ${SHARD02_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD02_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -55,7 +55,7 @@ done
 echo "The shard replset is available now..."
 
 CONFIG0_ID=$(sudo docker run -d ankurcha/tokumx mongod --configsvr  --dbpath /data/ --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT)
-CONFIG0_IP=$(sudo docker inspect ${CONFIG0_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+CONFIG0_IP=$(sudo docker inspect ${CONFIG0_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your config container ${CONFIG0_ID} listen on ip: ${CONFIG0_IP} (waiting that becomes ready)"
 
 until sudo docker logs ${CONFIG0_ID} | grep "waiting for connections on port" >/dev/null;
@@ -66,7 +66,7 @@ done
 echo "The config is available now..."
 
 MONGOS0_ID=$(sudo docker run -p 9999:9999 -d ankurcha/tokumx mongos --configdb ${CONFIG0_IP}:$PORT --logpath /dev/stdout --bind_ip 0.0.0.0 --port 9999)
-MONGOS0_IP=$(sudo docker inspect ${MONGOS0_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+MONGOS0_IP=$(sudo docker inspect ${MONGOS0_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Contacting shard and mongod containers"
 
 until sudo docker logs ${MONGOS0_ID} | grep "config servers and shards contacted successfully" >/dev/null;

--- a/bin/start-cluster.sh
+++ b/bin/start-cluster.sh
@@ -29,7 +29,7 @@ fi
 
 # start docker containers for 3xreplicaset rs0
 SHARD00_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet rs0 --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT)
-SHARD00_IP=$(sudo docker inspect ${SHARD00_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD00_IP=$(sudo docker inspect ${SHARD00_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD00_ID} listen on ip: ${SHARD00_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD00_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -37,7 +37,7 @@ do
 done
 
 SHARD01_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet rs0 --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT1)
-SHARD01_IP=$(sudo docker inspect ${SHARD01_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD01_IP=$(sudo docker inspect ${SHARD01_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD01_ID} listen on ip: ${SHARD01_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD01_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -45,7 +45,7 @@ do
 done
 
 SHARD02_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet rs0 --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT2)
-SHARD02_IP=$(sudo docker inspect ${SHARD02_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD02_IP=$(sudo docker inspect ${SHARD02_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD02_ID} listen on ip: ${SHARD02_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD02_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -62,7 +62,7 @@ done
 echo "The shard replset is available now..."
 
 CONFIG0_ID=$(sudo docker run -d ankurcha/tokumx mongod --configsvr  --dbpath /data/ --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT)
-CONFIG0_IP=$(sudo docker inspect ${CONFIG0_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+CONFIG0_IP=$(sudo docker inspect ${CONFIG0_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your config container ${CONFIG0_ID} listen on ip: ${CONFIG0_IP} (waiting that becomes ready)"
 
 until sudo docker logs ${CONFIG0_ID} | grep "waiting for connections on port" >/dev/null;
@@ -73,7 +73,7 @@ done
 echo "The config is available now..."
 
 MONGOS0_ID=$(sudo docker run -p $PORT_1:$PORT_1 -d ankurcha/tokumx mongos --configdb ${CONFIG0_IP}:$PORT --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT_1)
-MONGOS0_IP=$(sudo docker inspect ${MONGOS0_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+MONGOS0_IP=$(sudo docker inspect ${MONGOS0_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Contacting shard and mongod containers"
 
 until sudo docker logs ${MONGOS0_ID} | grep "config servers and shards contacted successfully" >/dev/null;

--- a/bin/start_singleShard.sh
+++ b/bin/start_singleShard.sh
@@ -18,7 +18,7 @@ set -e
 
 # start docker containers for 3xreplicaset $RS
 SHARD00_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet $RS --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT)
-SHARD00_IP=$(sudo docker inspect ${SHARD00_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD00_IP=$(sudo docker inspect ${SHARD00_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD00_ID} listen on ip: ${SHARD00_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD00_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -26,7 +26,7 @@ do
 done
 
 SHARD01_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet $RS --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT1)
-SHARD01_IP=$(sudo docker inspect ${SHARD01_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD01_IP=$(sudo docker inspect ${SHARD01_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD01_ID} listen on ip: ${SHARD01_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD01_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -34,7 +34,7 @@ do
 done
 
 SHARD02_ID=$(sudo docker run -d ankurcha/tokumx mongod --replSet $RS --shardsvr --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT2)
-SHARD02_IP=$(sudo docker inspect ${SHARD02_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+SHARD02_IP=$(sudo docker inspect ${SHARD02_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your shard container ${SHARD02_ID} listen on ip: ${SHARD02_IP} (waiting that becomes ready)"
 until sudo docker logs ${SHARD02_ID} | grep "replSet info you may need to run replSetInitiate" >/dev/null;
 do
@@ -51,7 +51,7 @@ done
 echo "The shard replset is available now..."
 
 CONFIG0_ID=$(sudo docker run -d ankurcha/tokumx mongod --configsvr  --dbpath /data/ --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT)
-CONFIG0_IP=$(sudo docker inspect ${CONFIG0_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+CONFIG0_IP=$(sudo docker inspect ${CONFIG0_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Your config container ${CONFIG0_ID} listen on ip: ${CONFIG0_IP} (waiting that becomes ready)"
 
 until sudo docker logs ${CONFIG0_ID} | grep "waiting for connections on port" >/dev/null;
@@ -62,7 +62,7 @@ done
 echo "The config is available now..."
 
 MONGOS0_ID=$(sudo docker run -p $PORT_1:$PORT_1 -d ankurcha/tokumx mongos --configdb ${CONFIG0_IP}:$PORT --logpath /dev/stdout --bind_ip 0.0.0.0 --port $PORT_1)
-MONGOS0_IP=$(sudo docker inspect ${MONGOS0_ID} | grep "IPAddress" | cut -d':' -f2 | cut -d'"' -f2)
+MONGOS0_IP=$(sudo docker inspect ${MONGOS0_ID} | grep '"IPAddress"' | cut -d':' -f2 | cut -d'"' -f2)
 echo "Contacting shard and mongod containers"
 
 until sudo docker logs ${MONGOS0_ID} | grep "config servers and shards contacted successfully" >/dev/null;


### PR DESCRIPTION
Fixed parsing of the IP address when inspecting docker containers.

Without this fix, the grep picks up `"SecondaryIPAddresses"` as well as the 
intended `"IPAddress"`.
